### PR TITLE
feat(calendar): iCal subscription feed for RSVP'd events

### DIFF
--- a/app/api/calendar/crud.py
+++ b/app/api/calendar/crud.py
@@ -86,10 +86,12 @@ def get_linked_emails(db: Session, citizen_id: int) -> List[str]:
     linked_ids = get_linked_citizen_ids(db, citizen_id)
     citizens = db.query(Citizen).filter(Citizen.id.in_(linked_ids)).all()
 
-    emails = set()
+    # The Social Layer `_in` filter matches profile.email exactly, so we must pass
+    # emails in their stored case (matching the existing event-count path). Dedupe
+    # case-insensitively but keep the first-seen original form.
+    by_lower: dict[str, str] = {}
     for citizen in citizens:
-        if citizen.primary_email:
-            emails.add(citizen.primary_email.lower())
-        if citizen.secondary_email:
-            emails.add(citizen.secondary_email.lower())
-    return sorted(emails)
+        for email in (citizen.primary_email, citizen.secondary_email):
+            if email and email.lower() not in by_lower:
+                by_lower[email.lower()] = email
+    return sorted(by_lower.values())

--- a/app/api/calendar/crud.py
+++ b/app/api/calendar/crud.py
@@ -1,0 +1,95 @@
+import secrets
+from typing import List, Optional
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.api.account_clusters.crud import get_linked_citizen_ids
+from app.api.citizens.models import Citizen
+
+from . import models
+
+# Length (in bytes) of the random subscription token. 32 bytes of entropy is plenty
+# for a bearer secret and matches the existing attendee-ticket key generation.
+_TOKEN_BYTES = 32
+
+
+def _generate_token() -> str:
+    return secrets.token_urlsafe(_TOKEN_BYTES)
+
+
+def get_by_citizen_id(
+    db: Session, citizen_id: int
+) -> Optional[models.CalendarSubscription]:
+    return (
+        db.query(models.CalendarSubscription)
+        .filter(models.CalendarSubscription.citizen_id == citizen_id)
+        .first()
+    )
+
+
+def get_by_token(db: Session, token: str) -> Optional[models.CalendarSubscription]:
+    if not token:
+        return None
+    return (
+        db.query(models.CalendarSubscription)
+        .filter(models.CalendarSubscription.token == token)
+        .first()
+    )
+
+
+def get_or_create(db: Session, citizen_id: int) -> models.CalendarSubscription:
+    """Return the citizen's subscription, creating one on first access."""
+    subscription = get_by_citizen_id(db, citizen_id)
+    if subscription:
+        return subscription
+
+    subscription = models.CalendarSubscription(
+        citizen_id=citizen_id, token=_generate_token()
+    )
+    db.add(subscription)
+    try:
+        db.commit()
+    except IntegrityError:
+        # A concurrent request already created the row; fall back to it.
+        db.rollback()
+        return get_by_citizen_id(db, citizen_id)
+    db.refresh(subscription)
+    return subscription
+
+
+def regenerate(db: Session, citizen_id: int) -> models.CalendarSubscription:
+    """Rotate the token, invalidating any previously shared URL."""
+    subscription = get_or_create(db, citizen_id)
+    subscription.token = _generate_token()
+    db.commit()
+    db.refresh(subscription)
+    return subscription
+
+
+def revoke(db: Session, citizen_id: int) -> bool:
+    """Delete the citizen's subscription. Returns False if there was nothing to revoke."""
+    subscription = get_by_citizen_id(db, citizen_id)
+    if not subscription:
+        return False
+    db.delete(subscription)
+    db.commit()
+    return True
+
+
+def get_linked_emails(db: Session, citizen_id: int) -> List[str]:
+    """All emails (primary + secondary, across linked accounts) for a citizen.
+
+    Mirrors how the profile aggregates events from Hasura so a user's RSVP feed
+    covers every email they may have used to RSVP in the Social Layer.
+    """
+    linked_ids = get_linked_citizen_ids(db, citizen_id)
+    citizens = db.query(Citizen).filter(Citizen.id.in_(linked_ids)).all()
+
+    emails = set()
+    for citizen in citizens:
+        if citizen.primary_email:
+            emails.add(citizen.primary_email.lower())
+        if citizen.secondary_email:
+            emails.add(citizen.secondary_email.lower())
+    return sorted(emails)

--- a/app/api/calendar/ics.py
+++ b/app/api/calendar/ics.py
@@ -1,0 +1,241 @@
+"""Fetch a citizen's RSVP'd events from the Social Layer and render an iCalendar feed.
+
+Individual events (talks, sessions, activities) are not stored in this backend; they
+live in the external Social Layer (Hasura GraphQL). "RSVP'd" means the citizen is a
+participant of the event, which is exactly the filter the profile/event-count code
+already uses. Recurring events come back from the Social Layer as one row per
+occurrence, so each RSVP'd occurrence is emitted as its own VEVENT (no RRULE needed).
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional
+
+import requests
+
+from app.core.config import settings
+from app.core.logger import logger
+from app.core.utils import current_time
+
+PRODID = '-//EdgeOS//Calendar Subscription//EN'
+# Hint to calendar clients on how often to re-poll the feed.
+REFRESH_INTERVAL = 'PT1H'
+_HTTP_TIMEOUT = 10
+
+# Preferred field set. If the Social Layer schema lacks one of the richer fields the
+# request errors out as a whole, so we retry with a minimal, known-safe projection.
+_EVENT_FIELDS_FULL = (
+    'id title start_time end_time timezone location event_type status tags content'
+)
+_EVENT_FIELDS_MIN = 'id title start_time end_time location'
+
+_QUERY_TEMPLATE = """
+query RsvpEvents($where: events_bool_exp) {{
+    events(where: $where) {{
+        {fields}
+    }}
+}}
+"""
+
+
+def fetch_rsvp_events(emails: List[str]) -> List[dict]:
+    """Return Social Layer events the given emails are participants of.
+
+    Never raises: on any error (network, GraphQL, misconfiguration) it logs and
+    returns an empty list so the feed stays a valid, empty calendar.
+    """
+    if not emails or not settings.HASURA_URL:
+        return []
+
+    where = {'participants': {'profile': {'email': {'_in': emails}}}}
+
+    for fields in (_EVENT_FIELDS_FULL, _EVENT_FIELDS_MIN):
+        query = _QUERY_TEMPLATE.format(fields=fields)
+        try:
+            response = requests.post(
+                settings.HASURA_URL,
+                headers={'Content-Type': 'application/json'},
+                json={'query': query, 'variables': {'where': where}},
+                timeout=_HTTP_TIMEOUT,
+            )
+            response.raise_for_status()
+            result = response.json()
+        except requests.RequestException as e:
+            logger.error('Failed to fetch RSVP events from Hasura: %s', e)
+            return []
+        except Exception as e:  # noqa: BLE001 - never let the feed 500
+            logger.error('Unexpected error fetching RSVP events: %s', e)
+            return []
+
+        if result.get('errors'):
+            # Likely an unknown field in the richer projection; try the minimal one.
+            logger.warning(
+                'Hasura GraphQL error (fields=%s): %s', fields, result['errors']
+            )
+            continue
+
+        return result.get('data', {}).get('events', []) or []
+
+    return []
+
+
+def build_calendar(events: List[dict], calendar_name: str) -> str:
+    """Render events as an RFC 5545 VCALENDAR string."""
+    now = _format_utc(current_time())
+
+    lines: List[str] = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        f'PRODID:{PRODID}',
+        'CALSCALE:GREGORIAN',
+        'METHOD:PUBLISH',
+        f'NAME:{_escape(calendar_name)}',
+        f'X-WR-CALNAME:{_escape(calendar_name)}',
+        f'REFRESH-INTERVAL;VALUE=DURATION:{REFRESH_INTERVAL}',
+        f'X-PUBLISHED-TTL:{REFRESH_INTERVAL}',
+    ]
+
+    for event in events:
+        lines.extend(_build_vevent(event, dtstamp=now))
+
+    lines.append('END:VCALENDAR')
+    return '\r\n'.join(_fold(line) for line in lines) + '\r\n'
+
+
+def _build_vevent(event: dict, dtstamp: str) -> List[str]:
+    start = _parse_dt(event.get('start_time'), event.get('timezone'))
+    if start is None:
+        # Without a start there is no valid VEVENT; skip it.
+        return []
+
+    end = _parse_dt(event.get('end_time'), event.get('timezone'))
+    if end is None or end <= start:
+        end = start + timedelta(hours=1)
+
+    uid = f'{event.get("id", _format_utc(start))}@sociallayer.edgeos'
+
+    block: List[str] = [
+        'BEGIN:VEVENT',
+        f'UID:{uid}',
+        f'DTSTAMP:{dtstamp}',
+        f'DTSTART:{_format_utc(start)}',
+        f'DTEND:{_format_utc(end)}',
+        f'SUMMARY:{_escape(event.get("title") or "Untitled event")}',
+        'STATUS:CONFIRMED',
+    ]
+
+    location = event.get('location')
+    if location:
+        block.append(f'LOCATION:{_escape(location)}')
+
+    description = event.get('content')
+    if description:
+        block.append(f'DESCRIPTION:{_escape(description)}')
+
+    categories = _categories(event)
+    if categories:
+        block.append(f'CATEGORIES:{categories}')
+
+    url = event.get('url')
+    if url:
+        block.append(f'URL:{_escape(url)}')
+
+    block.append('END:VEVENT')
+    return block
+
+
+def _categories(event: dict) -> str:
+    values: List[str] = []
+    event_type = event.get('event_type')
+    if event_type:
+        values.append(str(event_type))
+    tags = event.get('tags')
+    if isinstance(tags, list):
+        values.extend(str(t) for t in tags if t)
+    # CATEGORIES is a comma-separated TEXT list; escape each value.
+    return ','.join(_escape(v) for v in values)
+
+
+# ---------------------------------------------------------------------------
+# Datetime helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_dt(value: Optional[str], tz_name: Optional[str]) -> Optional[datetime]:
+    """Parse a Social Layer timestamp into an aware UTC datetime.
+
+    Social Layer timestamps are normally tz-aware (e.g. `2026-06-03T08:00:00+00:00`).
+    If a naive value comes back, fall back to the event's `timezone`, then to UTC.
+    """
+    if not value or not isinstance(value, str):
+        return None
+
+    normalized = value.strip().replace(' ', 'T')
+    if normalized.endswith('Z'):
+        normalized = normalized[:-1] + '+00:00'
+
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        logger.warning('Could not parse Social Layer timestamp: %s', value)
+        return None
+
+    if parsed.tzinfo is not None:
+        return parsed.astimezone(timezone.utc)
+
+    if tz_name:
+        try:
+            from zoneinfo import ZoneInfo
+
+            return parsed.replace(tzinfo=ZoneInfo(tz_name)).astimezone(timezone.utc)
+        except Exception:  # noqa: BLE001 - unknown tz / missing tzdata -> assume UTC
+            logger.warning('Unknown timezone %s; treating time as UTC', tz_name)
+
+    return parsed.replace(tzinfo=timezone.utc)
+
+
+def _format_utc(value: datetime) -> str:
+    """Format an (aware or naive-UTC) datetime as an iCalendar UTC stamp."""
+    if value.tzinfo is not None:
+        value = value.astimezone(timezone.utc).replace(tzinfo=None)
+    return value.strftime('%Y%m%dT%H%M%SZ')
+
+
+# ---------------------------------------------------------------------------
+# Text helpers (RFC 5545 §3.1, §3.3.11)
+# ---------------------------------------------------------------------------
+
+
+def _escape(text: str) -> str:
+    """Escape a TEXT value: backslash, semicolon, comma, and newlines."""
+    return (
+        str(text)
+        .replace('\\', '\\\\')
+        .replace(';', '\\;')
+        .replace(',', '\\,')
+        .replace('\r\n', '\\n')
+        .replace('\r', '\\n')
+        .replace('\n', '\\n')
+    )
+
+
+def _fold(line: str) -> str:
+    """Fold a content line to <=75 octets using CRLF + space continuations.
+
+    Folds on UTF-8 byte boundaries without splitting a multibyte character.
+    """
+    data = line.encode('utf-8')
+    if len(data) <= 75:
+        return line
+
+    chunks: List[bytes] = []
+    index = 0
+    # Conservative limit so a continuation (leading space + content) stays <= 75 octets.
+    limit = 73
+    while index < len(data):
+        end = min(index + limit, len(data))
+        # Back off so we never cut in the middle of a multibyte sequence.
+        while end < len(data) and (data[end] & 0xC0) == 0x80:
+            end -= 1
+        chunks.append(data[index:end])
+        index = end
+    return '\r\n '.join(chunk.decode('utf-8') for chunk in chunks)

--- a/app/api/calendar/models.py
+++ b/app/api/calendar/models.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+
+from sqlalchemy import ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+from app.core.utils import current_time
+
+
+class CalendarSubscription(Base):
+    """Per-citizen revocable token used to authenticate iCal feed requests.
+
+    Calendar apps poll the `.ics` feed unauthenticated (no cookies / OAuth), so the
+    bearer secret lives in the URL. There is a single active token per citizen; it can
+    be regenerated (rotates the token, old URL stops working) or revoked (row deleted).
+    """
+
+    __tablename__ = 'calendar_subscriptions'
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True, index=True)
+    citizen_id: Mapped[int] = mapped_column(
+        ForeignKey('humans.id'), unique=True, index=True
+    )
+    token: Mapped[str] = mapped_column(unique=True, index=True)
+    created_at: Mapped[datetime | None] = mapped_column(default=current_time)
+    updated_at: Mapped[datetime | None] = mapped_column(
+        default=current_time, onupdate=current_time
+    )

--- a/app/api/calendar/routes.py
+++ b/app/api/calendar/routes.py
@@ -100,6 +100,10 @@ def rsvp_feed(token: str, db: Session = Depends(get_db)):
         media_type='text/calendar; charset=utf-8',
         headers={
             'Content-Disposition': 'inline; filename="rsvp.ics"',
-            'Cache-Control': 'public, max-age=3600',
+            # The URL token is a per-user bearer secret, so the feed must never be
+            # stored by shared caches/CDNs — otherwise a revoked/regenerated token's
+            # old response could still be served. Clients learn the poll cadence from
+            # the in-body REFRESH-INTERVAL / X-PUBLISHED-TTL, not HTTP caching.
+            'Cache-Control': 'private, no-store',
         },
     )

--- a/app/api/calendar/routes.py
+++ b/app/api/calendar/routes.py
@@ -1,0 +1,105 @@
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.orm import Session
+
+from app.api.calendar import crud, ics, schemas
+from app.core.config import settings
+from app.core.database import get_db
+from app.core.security import TokenData, get_current_user
+
+router = APIRouter()
+
+
+def _feed_urls(token: str) -> tuple[str, str]:
+    """Return the (https, webcal) RSVP feed URLs for a token."""
+    base = settings.BACKEND_URL.rstrip('/')
+    https_url = f'{base}/calendar/{token}/rsvp.ics'
+
+    webcal_url = https_url
+    for scheme in ('https://', 'http://'):
+        if base.startswith(scheme):
+            webcal_url = 'webcal://' + https_url[len(scheme) :]
+            break
+    return https_url, webcal_url
+
+
+def _serialize(subscription) -> schemas.CalendarSubscriptionResponse:
+    https_url, webcal_url = _feed_urls(subscription.token)
+    return schemas.CalendarSubscriptionResponse(
+        token=subscription.token,
+        rsvp_ics_url=https_url,
+        rsvp_webcal_url=webcal_url,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Token management (authenticated with the citizen's JWT)
+# ---------------------------------------------------------------------------
+
+
+@router.get('/subscription', response_model=schemas.CalendarSubscriptionResponse)
+def get_subscription(
+    user: TokenData = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Return the current citizen's subscription token + feed URLs (creating it once)."""
+    return _serialize(crud.get_or_create(db, user.citizen_id))
+
+
+@router.post('/subscription', response_model=schemas.CalendarSubscriptionResponse)
+def create_subscription(
+    user: TokenData = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Idempotently create (or return) the citizen's subscription token."""
+    return _serialize(crud.get_or_create(db, user.citizen_id))
+
+
+@router.post(
+    '/subscription/regenerate',
+    response_model=schemas.CalendarSubscriptionResponse,
+)
+def regenerate_subscription(
+    user: TokenData = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Rotate the token; any previously shared URL stops working immediately."""
+    return _serialize(crud.regenerate(db, user.citizen_id))
+
+
+@router.delete('/subscription', status_code=status.HTTP_204_NO_CONTENT)
+def revoke_subscription(
+    user: TokenData = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Revoke (delete) the citizen's subscription token."""
+    crud.revoke(db, user.citizen_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# ---------------------------------------------------------------------------
+# Public feed (authenticated by the bearer token in the URL, not a JWT)
+# ---------------------------------------------------------------------------
+
+
+@router.get('/{token}/rsvp.ics')
+def rsvp_feed(token: str, db: Session = Depends(get_db)):
+    """Emit the token owner's RSVP'd Social Layer events as an iCalendar feed."""
+    subscription = crud.get_by_token(db, token)
+    if not subscription:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail='Invalid or revoked calendar token',
+        )
+
+    emails = crud.get_linked_emails(db, subscription.citizen_id)
+    events = ics.fetch_rsvp_events(emails)
+    body = ics.build_calendar(events, calendar_name="Edge — My RSVP'd Events")
+
+    return Response(
+        content=body,
+        media_type='text/calendar; charset=utf-8',
+        headers={
+            'Content-Disposition': 'inline; filename="rsvp.ics"',
+            'Cache-Control': 'public, max-age=3600',
+        },
+    )

--- a/app/api/calendar/schemas.py
+++ b/app/api/calendar/schemas.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+
+
+class CalendarSubscriptionResponse(BaseModel):
+    """Subscription token plus the URLs a user pastes into their calendar app."""
+
+    token: str
+    rsvp_ics_url: str
+    rsvp_webcal_url: str

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -1,6 +1,7 @@
 # Import all models here to ensure SQLAlchemy can set up relationships correctly
 from app.api.applications.models import Application
 from app.api.attendees.models import Attendee
+from app.api.calendar.models import CalendarSubscription
 from app.api.citizens.models import Citizen
 from app.api.email_logs.models import EmailLog
 from app.api.groups.models import Group
@@ -13,6 +14,7 @@ from app.api.products.models import Product
 __all__ = [
     'Application',
     'Attendee',
+    'CalendarSubscription',
     'Citizen',
     'EmailLog',
     'Group',

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from app.api.account_clusters.routes import router as account_clusters_router
 from app.api.achievements.routes import router as achievements_router
 from app.api.applications.routes import router as applications_router
 from app.api.attendees.routes import router as attendees_router
+from app.api.calendar.routes import router as calendar_router
 from app.api.check_in.routes import router as check_in_router
 from app.api.citizens.routes import router as citizens_router
 from app.api.coupon_codes.routes import router as coupon_codes_router
@@ -39,6 +40,7 @@ app.include_router(
 app.include_router(achievements_router, prefix='/achievements', tags=['Achievements'])
 app.include_router(applications_router, prefix='/applications', tags=['Applications'])
 app.include_router(attendees_router, prefix='/attendees', tags=['Attendees'])
+app.include_router(calendar_router, prefix='/calendar', tags=['Calendar'])
 app.include_router(check_in_router, prefix='/check-in', tags=['Check In'])
 app.include_router(citizens_router, prefix='/citizens', tags=['Citizens'])
 app.include_router(coupon_codes_router, prefix='/coupon-codes', tags=['Coupon Codes'])

--- a/migrations/versions/d4e5f6a7b8c9_add_calendar_subscriptions.py
+++ b/migrations/versions/d4e5f6a7b8c9_add_calendar_subscriptions.py
@@ -1,0 +1,65 @@
+"""add calendar_subscriptions table
+
+Revision ID: d4e5f6a7b8c9
+Revises: c3d4e5f6a7b8
+Create Date: 2026-06-03
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'd4e5f6a7b8c9'
+down_revision: Union[str, None] = 'c3d4e5f6a7b8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'calendar_subscriptions',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('citizen_id', sa.Integer(), nullable=False),
+        sa.Column('token', sa.String(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['citizen_id'], ['humans.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(
+        op.f('ix_calendar_subscriptions_id'),
+        'calendar_subscriptions',
+        ['id'],
+        unique=False,
+    )
+    op.create_index(
+        op.f('ix_calendar_subscriptions_citizen_id'),
+        'calendar_subscriptions',
+        ['citizen_id'],
+        unique=True,
+    )
+    op.create_index(
+        op.f('ix_calendar_subscriptions_token'),
+        'calendar_subscriptions',
+        ['token'],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f('ix_calendar_subscriptions_token'),
+        table_name='calendar_subscriptions',
+    )
+    op.drop_index(
+        op.f('ix_calendar_subscriptions_citizen_id'),
+        table_name='calendar_subscriptions',
+    )
+    op.drop_index(
+        op.f('ix_calendar_subscriptions_id'),
+        table_name='calendar_subscriptions',
+    )
+    op.drop_table('calendar_subscriptions')

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from app.api.calendar import ics
+from app.api.calendar import crud, ics
 from app.core.config import settings
 from tests.conftest import get_auth_headers_for_citizen
 
@@ -136,6 +136,39 @@ def test_feed_with_no_events_is_valid_empty_calendar(client, auth_headers):
     assert response.status_code == 200
     assert 'BEGIN:VCALENDAR' in response.text
     assert 'BEGIN:VEVENT' not in response.text
+
+
+def test_feed_is_not_publicly_cacheable(client, auth_headers):
+    """The token is a bearer secret, so shared caches must not store the feed
+    (otherwise a revoked token's old response could still be served)."""
+    token = client.post('/calendar/subscription', headers=auth_headers).json()['token']
+
+    with patch(f'{ICS_MODULE}.fetch_rsvp_events', return_value=[]):
+        response = client.get(f'/calendar/{token}/rsvp.ics')
+
+    cache_control = response.headers.get('cache-control', '')
+    assert 'public' not in cache_control
+    assert 'no-store' in cache_control
+
+
+# ---------------------------------------------------------------------------
+# Linked-email resolution
+# ---------------------------------------------------------------------------
+
+
+def test_get_linked_emails_preserves_stored_case(db_session, create_test_citizen):
+    """Social Layer matches profile.email exactly, so stored case must be kept
+    (mirrors the existing event-count path) rather than lowercased."""
+    citizen = create_test_citizen(1)
+    citizen.primary_email = 'Mixed.Case@Example.com'
+    citizen.secondary_email = 'Second@Example.COM'
+    db_session.commit()
+
+    emails = crud.get_linked_emails(db_session, citizen.id)
+
+    assert 'Mixed.Case@Example.com' in emails
+    assert 'Second@Example.COM' in emails
+    assert 'mixed.case@example.com' not in emails  # not lowercased
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,0 +1,260 @@
+from datetime import datetime, timezone
+from unittest.mock import Mock, patch
+
+import pytest
+
+from app.api.calendar import ics
+from app.core.config import settings
+from tests.conftest import get_auth_headers_for_citizen
+
+ICS_MODULE = 'app.api.calendar.ics'
+
+
+# ---------------------------------------------------------------------------
+# Token management endpoints
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def backend_url():
+    """Pin BACKEND_URL so feed URLs (incl. webcal://) are deterministic."""
+    original = settings.BACKEND_URL
+    settings.BACKEND_URL = 'https://api.edgeos.test'
+    yield settings.BACKEND_URL
+    settings.BACKEND_URL = original
+
+
+def test_get_subscription_creates_and_is_idempotent(
+    client, test_citizen, auth_headers, backend_url
+):
+    first = client.get('/calendar/subscription', headers=auth_headers)
+    assert first.status_code == 200
+    body = first.json()
+    token = body['token']
+
+    assert token
+    assert body['rsvp_ics_url'] == f'{backend_url}/calendar/{token}/rsvp.ics'
+    assert body['rsvp_webcal_url'] == (
+        f'webcal://api.edgeos.test/calendar/{token}/rsvp.ics'
+    )
+
+    # A second call returns the same token (get-or-create, not a new one each time).
+    second = client.get('/calendar/subscription', headers=auth_headers)
+    assert second.json()['token'] == token
+
+
+def test_regenerate_rotates_token(client, test_citizen, auth_headers, backend_url):
+    original = client.post('/calendar/subscription', headers=auth_headers).json()[
+        'token'
+    ]
+    rotated = client.post(
+        '/calendar/subscription/regenerate', headers=auth_headers
+    ).json()['token']
+
+    assert rotated != original
+    # The rotated token resolves; the old one no longer does.
+    assert client.get(f'/calendar/{rotated}/rsvp.ics').status_code == 200
+    assert client.get(f'/calendar/{original}/rsvp.ics').status_code == 404
+
+
+def test_revoke_deletes_token(client, test_citizen, auth_headers):
+    token = client.post('/calendar/subscription', headers=auth_headers).json()['token']
+    assert client.get(f'/calendar/{token}/rsvp.ics').status_code == 200
+
+    deleted = client.delete('/calendar/subscription', headers=auth_headers)
+    assert deleted.status_code == 204
+    assert client.get(f'/calendar/{token}/rsvp.ics').status_code == 404
+
+
+def test_subscription_requires_auth(client):
+    assert client.get('/calendar/subscription').status_code == 401
+
+
+def test_tokens_are_isolated_per_citizen(client, create_test_citizen, backend_url):
+    citizen_a = create_test_citizen(1)
+    citizen_b = create_test_citizen(2)
+
+    token_a = client.post(
+        '/calendar/subscription', headers=get_auth_headers_for_citizen(citizen_a.id)
+    ).json()['token']
+    token_b = client.post(
+        '/calendar/subscription', headers=get_auth_headers_for_citizen(citizen_b.id)
+    ).json()['token']
+
+    assert token_a != token_b
+
+
+# ---------------------------------------------------------------------------
+# Feed endpoint
+# ---------------------------------------------------------------------------
+
+SAMPLE_EVENTS = [
+    {
+        'id': 'evt-1',
+        'title': 'Qi Gong',
+        'start_time': '2026-06-03T08:00:00+00:00',
+        'end_time': '2026-06-03T08:45:00+00:00',
+        'location': 'The Hub - Wellness Space',
+        'event_type': 'Exercise',
+        'tags': ['wellness'],
+        'content': 'A moving meditation.',
+    }
+]
+
+
+def test_feed_invalid_token_returns_404(client):
+    assert client.get('/calendar/not-a-real-token/rsvp.ics').status_code == 404
+
+
+def test_feed_renders_rsvp_events(client, test_citizen, auth_headers):
+    token = client.post('/calendar/subscription', headers=auth_headers).json()['token']
+
+    with patch(f'{ICS_MODULE}.fetch_rsvp_events', return_value=SAMPLE_EVENTS) as mocked:
+        response = client.get(f'/calendar/{token}/rsvp.ics')
+
+    assert response.status_code == 200
+    assert response.headers['content-type'].startswith('text/calendar')
+    body = response.text
+    assert body.startswith('BEGIN:VCALENDAR')
+    assert body.strip().endswith('END:VCALENDAR')
+    assert 'BEGIN:VEVENT' in body
+    assert 'SUMMARY:Qi Gong' in body
+    assert 'DTSTART:20260603T080000Z' in body
+    assert 'DTEND:20260603T084500Z' in body
+
+    # The feed resolves the token to the citizen and queries by their linked email.
+    called_emails = mocked.call_args.args[0]
+    assert test_citizen.primary_email.lower() in called_emails
+
+
+def test_feed_with_no_events_is_valid_empty_calendar(client, auth_headers):
+    token = client.post('/calendar/subscription', headers=auth_headers).json()['token']
+
+    with patch(f'{ICS_MODULE}.fetch_rsvp_events', return_value=[]):
+        response = client.get(f'/calendar/{token}/rsvp.ics')
+
+    assert response.status_code == 200
+    assert 'BEGIN:VCALENDAR' in response.text
+    assert 'BEGIN:VEVENT' not in response.text
+
+
+# ---------------------------------------------------------------------------
+# Social Layer fetch
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_returns_empty_without_emails():
+    assert ics.fetch_rsvp_events([]) == []
+
+
+def test_fetch_returns_empty_without_hasura_url(monkeypatch):
+    monkeypatch.setattr(settings, 'HASURA_URL', '')
+    assert ics.fetch_rsvp_events(['a@example.com']) == []
+
+
+def _mock_response(payload):
+    response = Mock()
+    response.raise_for_status = Mock()
+    response.json.return_value = payload
+    return response
+
+
+def test_fetch_falls_back_to_minimal_fields_on_graphql_error(monkeypatch):
+    monkeypatch.setattr(settings, 'HASURA_URL', 'https://hasura.test/graphql')
+    responses = [
+        _mock_response({'errors': [{'message': "field 'content' not found"}]}),
+        _mock_response({'data': {'events': SAMPLE_EVENTS}}),
+    ]
+    with patch(f'{ICS_MODULE}.requests.post', side_effect=responses) as post:
+        events = ics.fetch_rsvp_events(['a@example.com'])
+
+    assert events == SAMPLE_EVENTS
+    assert post.call_count == 2  # rich query failed, minimal query succeeded
+
+
+def test_fetch_swallows_network_errors(monkeypatch):
+    import requests
+
+    monkeypatch.setattr(settings, 'HASURA_URL', 'https://hasura.test/graphql')
+    with patch(
+        f'{ICS_MODULE}.requests.post', side_effect=requests.RequestException('boom')
+    ):
+        assert ics.fetch_rsvp_events(['a@example.com']) == []
+
+
+# ---------------------------------------------------------------------------
+# ICS serializer
+# ---------------------------------------------------------------------------
+
+
+def test_build_calendar_skips_events_without_start():
+    body = ics.build_calendar([{'id': 'x', 'title': 'No start'}], 'Test')
+    assert 'BEGIN:VEVENT' not in body
+
+
+def test_build_calendar_defaults_missing_end_to_one_hour():
+    body = ics.build_calendar(
+        [{'id': 'x', 'title': 'T', 'start_time': '2026-06-03T08:00:00+00:00'}], 'Test'
+    )
+    assert 'DTSTART:20260603T080000Z' in body
+    assert 'DTEND:20260603T090000Z' in body
+
+
+def test_build_calendar_escapes_text():
+    body = ics.build_calendar(
+        [
+            {
+                'id': 'x',
+                'title': 'Talk: A, B; C',
+                'start_time': '2026-06-03T08:00:00+00:00',
+                'content': 'line one\nline two',
+            }
+        ],
+        'Test',
+    )
+    assert 'SUMMARY:Talk: A\\, B\\; C' in body
+    assert 'DESCRIPTION:line one\\nline two' in body
+
+
+def test_naive_time_uses_event_timezone():
+    body = ics.build_calendar(
+        [
+            {
+                'id': 'x',
+                'title': 'T',
+                'start_time': '2026-06-03T08:00:00',
+                'timezone': 'America/Los_Angeles',
+            }
+        ],
+        'Test',
+    )
+    # 08:00 PDT (UTC-7 in June) == 15:00 UTC
+    assert 'DTSTART:20260603T150000Z' in body
+
+
+def test_all_lines_respect_75_octet_fold_limit():
+    long_title = 'A very long event title ' * 10  # > 75 octets
+    body = ics.build_calendar(
+        [{'id': 'x', 'title': long_title, 'start_time': '2026-06-03T08:00:00+00:00'}],
+        'Test',
+    )
+    for line in body.split('\r\n'):
+        assert len(line.encode('utf-8')) <= 75
+
+
+def test_uses_crlf_line_endings():
+    body = ics.build_calendar(SAMPLE_EVENTS, 'Test')
+    assert '\r\n' in body
+    # No bare LF that isn't part of a CRLF pair.
+    assert '\n' not in body.replace('\r\n', '')
+
+
+def test_output_parses_with_icalendar_when_available():
+    """Spec-compliance check using a real parser when one is installed."""
+    icalendar = pytest.importorskip('icalendar')
+    body = ics.build_calendar(SAMPLE_EVENTS, "Edge — My RSVP'd Events")
+    cal = icalendar.Calendar.from_ical(body)
+    events = [c for c in cal.walk() if c.name == 'VEVENT']
+    assert len(events) == 1
+    assert str(events[0]['SUMMARY']) == 'Qi Gong'
+    assert events[0]['DTSTART'].dt == datetime(2026, 6, 3, 8, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
## What & why

Adds **calendar subscription URLs** so a user can paste a link into Apple/Google/Outlook Calendar and have their **RSVP'd events** auto-sync. Calendar apps fetch subscription URLs unauthenticated (no cookies / interactive OAuth), so this uses a **per-user, revocable subscription token embedded in the URL**.

Individual events (talks, sessions, activities) are **not** stored in this backend — they live in the external **Social Layer** (Hasura GraphQL). "RSVP'd" means the citizen is a *participant*, which is exactly the filter the profile/`_get_events_count` code already uses against `HASURA_URL`. The feed resolves the token → citizen → **linked emails** (across merged accounts) → Hasura → spec-compliant iCalendar.

> Scope: this is the **RSVP'd-events feed only**. An "all events" feed was intentionally deferred (it needs a popup→Social-Layer-group mapping that doesn't exist yet).

## Endpoints (mounted at `/calendar`)

| Method | Path | Auth | Purpose |
|---|---|---|---|
| `GET`/`POST` | `/calendar/subscription` | JWT | Get-or-create the citizen's token + feed URLs |
| `POST` | `/calendar/subscription/regenerate` | JWT | Rotate the token (old URL stops working) |
| `DELETE` | `/calendar/subscription` | JWT | Revoke the token |
| `GET` | `/calendar/{token}/rsvp.ics` | token-in-URL | The iCalendar feed (`text/calendar`) |

Feed URL shape: `https://<backend>/calendar/{token}/rsvp.ics` (also surfaced as `webcal://…`).

## Implementation notes

- **New `CalendarSubscription` model** (one revocable token per citizen) + **Alembic migration** chained off the current head `c3d4e5f6a7b8`. Mirrors the existing `AttendeeTicketApiKey` token pattern (`secrets.token_urlsafe(32)`).
- **Hand-rolled RFC 5545 serializer** — deliberately **no new runtime dependency** (avoids `uv.lock` churn). Emits `UID`, `DTSTAMP`, `DTSTART`/`DTEND` (UTC), `SUMMARY`, `LOCATION`, `DESCRIPTION`, `CATEGORIES`, `STATUS`, plus `REFRESH-INTERVAL`/`X-PUBLISHED-TTL` refresh hints. Correct 75-octet line folding (UTF-8 aware) and TEXT escaping.
- **Recurring events**: the Social Layer returns one row per occurrence, so each RSVP'd occurrence becomes its own `VEVENT` (no `RRULE` needed).
- **Resilient fetch**: a field-fallback GraphQL query (rich projection → minimal projection) and total error-swallowing so the endpoint always returns a *valid* calendar (empty rather than 500) if the Social Layer is unreachable.

## Sample output

```ics
BEGIN:VCALENDAR
VERSION:2.0
PRODID:-//EdgeOS//Calendar Subscription//EN
CALSCALE:GREGORIAN
METHOD:PUBLISH
NAME:Edge — My RSVP'd Events
REFRESH-INTERVAL;VALUE=DURATION:PT1H
X-PUBLISHED-TTL:PT1H
BEGIN:VEVENT
UID:qigong-w1@sociallayer.edgeos
DTSTAMP:20260603T185830Z
DTSTART:20260603T150000Z
DTEND:20260603T154500Z
SUMMARY:Qi Gong
STATUS:CONFIRMED
LOCATION:The Hub - Wellness Space - 405 Healdsburg Ave
DESCRIPTION:A moving meditation rooted in Traditional Chinese Medicine.\n…
CATEGORIES:Exercise,wellness,movement
END:VEVENT
END:VCALENDAR
```

(08:00 `America/Los_Angeles` → `15:00Z`; comma/semicolon/newline escaped; long lines folded.)

## Testing

- **19 new tests** (`tests/test_calendar.py`): token lifecycle (create/idempotent/regenerate/revoke/auth-required/per-citizen isolation), the feed (valid token, invalid token → 404, empty calendar, linked-email resolution), the Social Layer fetch (no-emails, no-`HASURA_URL`, field-fallback, network-error swallowing), and the serializer (escaping, folding ≤75 octets, CRLF, timezone conversion, missing-end default, skip-no-start).
- Output **validated against a real iCalendar parser** (`icalendar`, dev-only — not added to project deps).
- Full existing suite still green: **150 passed**.
- Migration `upgrade()`/`downgrade()` verified against SQLite (correct columns, unique indexes on `citizen_id`/`token`, FK to `humans`).

## Frontend

The companion Citizen-Portal PR (surfacing these URLs on the profile page with copy / `webcal://` subscribe / regenerate) depends on this and will reference it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
